### PR TITLE
Мидраунд события

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -84,7 +84,7 @@
     duration: 1
     earliestStart: 45
     reoccurrenceDelay: 60
-    minimumPlayers: 20
+    minimumPlayers: 35
   - type: RandomSpawnRule
     prototype: SpawnPointGhostDragon
 
@@ -110,7 +110,7 @@
     weight: 7.5
     duration: 1
     earliestStart: 45
-    minimumPlayers: 20
+    minimumPlayers: 30
   - type: RandomSpawnRule
     prototype: MobRevenant
 
@@ -392,7 +392,7 @@
   - type: StationEvent
     earliestStart: 50
     weight: 5
-    minimumPlayers: 35
+    minimumPlayers: 80
     duration: 1
   - type: ZombieRule
     minStartDelay: 0 #let them know immediately
@@ -409,7 +409,7 @@
   - type: StationEvent
     earliestStart: 45
     weight: 5
-    minimumPlayers: 30
+    minimumPlayers: 50
     reoccurrenceDelay: 30
     duration: 1
   - type: LoneOpsSpawnRule
@@ -442,7 +442,7 @@
     weight: 5
     duration: 1
     earliestStart: 45
-    minimumPlayers: 20
+    minimumPlayers: 30
   - type: ImmovableRodRule
 
 - type: entity


### PR DESCRIPTION
Изменение требований к количеству игроков для мидраунд событий ради минимизации рисков испорченных ночных и просто спокойных раундов.

:cl:
- tweak: Поднял минимально требуемое количество игроков для некоторых событий
