### PR TITLE
небольшие изменения ядерных оперативников

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -30,7 +30,7 @@ public sealed partial class NukeopsRuleComponent : Component
     public int PlayersPerOperative = 7;
 
     [DataField]
-    public int MaxOps = 5;
+    public int MaxOps = 4;
 
     /// <summary>
     /// What will happen if all of the nuclear operatives will die. Used by LoneOpsSpawn event.

--- a/Resources/Prototypes/ADT/Catalog/uplink.yml
+++ b/Resources/Prototypes/ADT/Catalog/uplink.yml
@@ -58,7 +58,7 @@
   icon: { sprite: /Textures/Objects/Weapons/Guns/Snipers/heavy_sniper.rsi, state: base }
   productEntity: ADTClothingBackpackDuffelSyndicateFilledHristov
   cost:
-    Telecrystal: 20
+    Telecrystal: 15
   categories:
   - UplinkBundles
   conditions:
@@ -210,7 +210,7 @@
   description: uplink-ADTHandDefibrillator-desc
   productEntity: ADTHandDefibrillator
   cost:
-    Telecrystal: 25
+    Telecrystal: 4
   categories:
   - UplinkMisc
   conditions:

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -7,7 +7,7 @@
   description: uplink-pistol-viper-desc
   productEntity: WeaponPistolViper
   cost:
-    Telecrystal: 3
+    Telecrystal: 2
   categories:
   - UplinkWeapons
 
@@ -71,7 +71,7 @@
   description: uplink-gloves-north-star-desc
   productEntity: ClothingHandsGlovesNorthStar
   cost:
-    Telecrystal: 8
+    Telecrystal: 7
   categories:
   - UplinkWeapons
 
@@ -116,11 +116,6 @@
     Telecrystal: 8
   categories:
   - UplinkWeapons
-  conditions:
-    - !type:StoreWhitelistCondition
-      blacklist:
-        tags:
-          - NukeOpsUplink
 
 # Explosives
 
@@ -219,7 +214,7 @@
   description: uplink-grenadier-rig-desc
   productEntity: ClothingBeltMilitaryWebbingGrenadeFilled
   cost:
-    Telecrystal: 12
+    Telecrystal: 10
   categories:
   - UplinkExplosives
   conditions:
@@ -255,7 +250,7 @@
   icon: { sprite: /Textures/Objects/Misc/bureaucracy.rsi, state: pen }
   productEntity: PenExplodingBox
   cost:
-    Telecrystal: 3
+    Telecrystal: 2
   categories:
   - UplinkExplosives
 
@@ -265,10 +260,10 @@
   description: uplink-exploding-syndicate-bomb-desc
   productEntity: SyndicateBomb
   cost:
-    Telecrystal: 11
+    Telecrystal: 8
   categories:
     - UplinkExplosives
-  restockTime: 30
+  restockTime: 20
 
 - type: listing
   id: UplinkClusterGrenade
@@ -840,7 +835,7 @@
   description: uplink-meds-bundle-desc
   productEntity: ClothingBackpackDuffelSyndicateMedicalBundleFilled
   cost:
-    Telecrystal: 15
+    Telecrystal: 10
   categories:
   - UplinkBundles
   conditions:
@@ -913,7 +908,7 @@
   icon: { sprite: /Textures/Objects/Weapons/Guns/Launchers/china_lake.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateFilledGrenadeLauncher
   cost:
-    Telecrystal: 35
+    Telecrystal: 30
   categories:
   - UplinkBundles
   conditions:
@@ -953,18 +948,10 @@
   icon: { sprite: /Textures/Structures/Wallmounts/signs.rsi, state: bio }
   productEntity: ClothingBackpackDuffelZombieBundle
   cost:
-    Telecrystal: 40
+    Telecrystal: 30
   categories:
   - UplinkBundles
-  conditions:
-  - !type:StoreWhitelistCondition
-    whitelist:
-      tags:
-      - NukeOpsUplink
-  - !type:BuyerWhitelistCondition
-    blacklist:
-      components:
-      - SurplusBundle
+
 
 - type: listing
   id: UplinkSurplusBundle

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -371,10 +371,10 @@
     sprite: Clothing/Hands/Gloves/northstar.rsi
   - type: MeleeWeapon
     autoAttack: true
-    attackRate: 4
+    attackRate: 5
     damage:
       types:
-       Blunt: 8
+       Blunt: 12
     soundHit:
       collection: Punch
     animation: WeaponArcFist

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
@@ -7,6 +7,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 90
+        Piercing: 125
         Structural: 100
+  - type: StaminaDamageOnCollide
+    damage: 60
     #ignoreResistances: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -45,7 +45,7 @@
     whitelist:
       tags:
         - Grenade
-    capacity: 3
+    capacity: 1
     proto: GrenadeFrag
     soundInsert:
       path: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg

--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -123,9 +123,9 @@
       softness: 1
     - type: Explosive
       explosionType: HardBomb
-      totalIntensity: 4000.0
-      intensitySlope: 3
-      maxIntensity: 400
+      totalIntensity: 5000.0
+      intensitySlope: 4
+      maxIntensity: 500
 
 - type: entity
   parent: SyndicateBomb


### PR DESCRIPTION
Уменьшил некоторые цены в аплинке
Уменьшил число ядерщиков с 5=>4
Увеличил урон перчаток северной звезды с 8=>12 (для будущего введения спец перчаток)
Ядерщики теперь могут быть engeneerTF2gameplay (раскладная турель стала доступна для покупки)
Слегка бафнул бомбу синдиката
Христов воссияет снова. 
- урон увеличен 90 => 125
- останавливающие действие, добавлено 60 урона по стамине
Боевой дефиб сильно упал в цене 25=>4 
У чайналейка теперь только одна граната в стволе
