### PR TITLE
Разделение инструментов

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -245,9 +245,10 @@
     - state: icon-tools-adv
   - type: ItemBorgModule
     items:
-    - Omnitool
+    - PowerDrill
+    - JawsOfLife
     - WelderExperimental
-    - NetworkConfigurator
+    - Multitool
 
 - type: entity
   id: BorgModuleGasAnalyzer


### PR DESCRIPTION
Из #Предложения для сервера
Разделение инструментов у инженерного киборга 
Омнитул довольно не эффективен в использовании и он медленней чем дрель или те же челюсти 
Так же очень неудобно в использовании из-за постоянного перебора инструментов аж 3-4 раза чтобы подобрать нужный, новые инструменты таких недостатков не имеют