### PR TITLE
чуть больше веселья

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -443,7 +443,7 @@ namespace Content.Shared.CCVar
             CVarDef.Create("traitor.max_traitors", 4); // Assuming average server maxes somewhere from like 50-80 people
 
         public static readonly CVarDef<int> TraitorPlayersPerTraitor =
-            CVarDef.Create("traitor.players_per_traitor", 15);
+            CVarDef.Create("traitor.players_per_traitor", 12);
 
         public static readonly CVarDef<int> TraitorCodewordCount =
             CVarDef.Create("traitor.codeword_count", 4);
@@ -496,7 +496,7 @@ namespace Content.Shared.CCVar
 
         public static readonly CVarDef<int> ChangelingMinPlayers =
 
-            CVarDef.Create("changeling.min_players", 20);
+            CVarDef.Create("changeling.min_players", 5);
 
         public static readonly CVarDef<int> ChangelingMaxChangelings =
             CVarDef.Create("changeling.max_lings", 2); // Assuming average server maxes somewhere from like 50-80 people. Upd: У нас генокрады вместе с предателями, куда бля! Порезал в 2 раза лимит.

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,9 +1,8 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.1
-    Traitor: 0.60
-    Zombie: 0.075
+    Nukeops: 0.15
+    Traitor: 0.6
+    Zombie: 0.1
     Survival: 0.05
-    Extended: 0.10
-    Revolutionary: 0.075
+    Revolutionary: 0.1


### PR DESCRIPTION
Для того, чтобы секрет запускался и на меньшем, чем 20 готовых игроков - для генокрада минимальное количество игроков уменьшено до 5. Но само количество игроков на генокрада таково, что игроков надо много для хотя бы одного гены. 

Убрал шанс расширки из секрета, чуть увеличил шанс динамичных режимов, шанс трейторов - такой же