### PR TITLE
Knife overhaul

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Objects/Weapons/Melee/AstraKnife.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Weapons/Melee/AstraKnife.yml
@@ -27,3 +27,11 @@
     sprite: ADT/Objects/Weapons/Melee/astra-knife.rsi
   - type: DisarmMalus
     malus: 0.225
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 10
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: ThrowingAngle
+    angle: 225

--- a/Resources/Prototypes/ADT/Entities/Objects/Weapons/Melee/BoneKnife.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Weapons/Melee/BoneKnife.yml
@@ -26,3 +26,5 @@
   - type: Clothing
     slots:
     - Belt
+  - type: ThrowingAngle
+    angle: 225

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -108,6 +108,10 @@
     sprite: Objects/Weapons/Melee/combat_knife.rsi
   - type: DisarmMalus
     malus: 0.225
+##ADT add start
+  - type: ThrowingAngle
+    angle: 225
+##ADT add end
 
 - type: entity
   name: survival knife
@@ -168,6 +172,10 @@
     sprite: Objects/Weapons/Melee/shiv.rsi
   - type: DisarmMalus
     malus: 0.225
+##ADT add start
+  - type: ThrowingAngle
+    angle: 200
+##ADT add end
 
 - type: entity
   name: reinforced shiv

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -86,6 +86,26 @@
   - type: Tag
     tags:
     - Knife
+##ADT add start
+  - type: Utensil
+    types:
+      - Knife
+  - type: Tool
+    qualities:
+      - Prying
+    speed: 0.65
+  - type: Prying
+  - type: DisarmMalus
+    malus: 0.225
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 12
+  - type: ThrowingAngle
+    angle: 225
+##ADT add end
 
 # Like a crusher... but sucks
 - type: entity


### PR DESCRIPTION
## Описание PR
Данный PR в основном нацелен на улучшение метания ножей: ножи кидаются как обычные предметы, за сим видеть нож, застрявший рукоятью в противнике/стене крайне несуразно. Данный PR исправляет это недоразумение. Ну и ещё нож-крашер стал наконец-то полноценным ножом, который может резать продукты.
![изображение_2024-04-08_030342633](https://github.com/xtray85/space_station/assets/143436581/a8b50deb-684c-41b2-b7bd-1c21a2cecc9d)
![изображение_2024-04-08_030503861](https://github.com/xtray85/space_station/assets/143436581/056000fd-23a7-4d95-88df-ff07165e2aa1)
![изображение_2024-04-08_032738448](https://github.com/xtray85/space_station/assets/143436581/26cac1f5-4206-46e0-baaa-a1474a2d7e1c)

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl: Username228
- tweak: Ножи теперь метаются острым концом вперёд. Вам более не придётся хвататься за острое лезвие ножа, чтобы вытащить застрявшую рукоятку в туше врага.
- tweak: Нож-крашер теперь может рубить продукты питания, такие как торт, хлеб и так далее.
- tweak: Нож-крашер теперь может вскрывать обесточенные двери, как лом. Правда, вскрывать дверь вы им будете чуть дольше, чем обычным ломом.