### PR TITLE
cargoConsoleMenu localization. addition to 6e38b992

### DIFF
--- a/Resources/Prototypes/ADT/Catalog/Cargo/cargo_adt.yml
+++ b/Resources/Prototypes/ADT/Catalog/Cargo/cargo_adt.yml
@@ -6,7 +6,7 @@
     state: patchpack
   product: ADTCratePatchPackFilled
   cost: 1600
-  category: Medical
+  category: cargoproduct-category-name-medical
   group: market
 
 #engineering
@@ -38,7 +38,7 @@
     state: base
   product: ADTCrateVendingMachineRestockPillFilled
   cost: 1200
-  category: Medical
+  category: cargoproduct-category-name-medical
   group: market
 
 #crates

--- a/Resources/Prototypes/ADT/Catalog/Fills/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/ADT/Catalog/Fills/Cargo/cargo_armory.yml
@@ -5,7 +5,7 @@
 #    state: syringe_base0
 #  product: ADTCrateMindshieldImplants
 #  cost: 3000
-#  category: Armory
+#  category: cargoproduct-category-name-armory
 #  group: market
 
 - type: cargoProduct
@@ -15,7 +15,7 @@
     state: icon
   product: ADTCrateArmoryUSSPPistols
   cost: 3500
-  category: Armory
+  category: cargoproduct-category-name-armory
   group: market
 
 - type: cargoProduct
@@ -25,5 +25,5 @@
     state: icon
   product: ADTCrateArmorySALR36
   cost: 29000
-  category: Armory
+  category: cargoproduct-category-name-armory
   group: market

--- a/Resources/Prototypes/ADT/Catalog/Fills/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/ADT/Catalog/Fills/Cargo/cargo_food.yml
@@ -7,7 +7,7 @@
     state: brezel_salt
   product: ADTCrateOktoberfestSnack
   cost: 650
-  category: Food
+  category: cargoproduct-category-name-food
   group: market
 
 - type: cargoProduct
@@ -17,7 +17,7 @@
     state: beer
   product: ADTBeerTank
   cost: 150
-  category: Food
+  category: cargoproduct-category-name-food
   group: market
 
 - type: cargoProduct
@@ -27,7 +27,7 @@
     state: goldenale
   product: ADTBeerTankGoldenAle
   cost: 150
-  category: Food
+  category: cargoproduct-category-name-food
   group: market
 
 - type: cargoProduct
@@ -37,7 +37,7 @@
     state: sausagebeer
   product: ADTBeerTankSausage
   cost: 150
-  category: Food
+  category: cargoproduct-category-name-food
   group: market
 
 - type: cargoProduct
@@ -47,7 +47,7 @@
     state: technobeer
   product: ADTBeerTankTechno
   cost: 150
-  category: Food
+  category: cargoproduct-category-name-food
   group: market
 
 - type: cargoProduct
@@ -57,7 +57,7 @@
     state: paulanerbeer
   product: ADTBeerTankClassicPaulaner
   cost: 150
-  category: Food
+  category: cargoproduct-category-name-food
   group: market
 
 - type: cargoProduct
@@ -67,7 +67,7 @@
     state: livseybeer
   product: ADTBeerTankLivsey
   cost: 150
-  category: Food
+  category: cargoproduct-category-name-food
   group: market
 
 - type: cargoProduct
@@ -77,7 +77,7 @@
     state: luckyjonnybeer
   product: ADTBeerTankLuckyJonny
   cost: 150
-  category: Food
+  category: cargoproduct-category-name-food
   group: market
 
 - type: cargoProduct
@@ -87,7 +87,7 @@
     state: secunfilteredbeer
   product: ADTBeerTankSecUnfiltered
   cost: 150
-  category: Food
+  category: cargoproduct-category-name-food
   group: market
 
 - type: cargoProduct
@@ -97,7 +97,7 @@
     state: glyphidstout
   product: ADTBeerTankGlyphidStout
   cost: 150
-  category: Food
+  category: cargoproduct-category-name-food
   group: market
 
 - type: cargoProduct
@@ -107,7 +107,7 @@
     state: icon-0
   product: ADTCrateHalloweenFood
   cost: 1200
-  category: Food
+  category: cargoproduct-category-name-food
   group: market
 
 - type: cargoProduct
@@ -117,7 +117,7 @@
     state: chocogorilla
   product: ADTCrateChocolateGorilla
   cost: 1000
-  category: Food
+  category: cargoproduct-category-name-food
   group: market
 
 - type: cargoProduct
@@ -127,5 +127,5 @@
     state: fish
   product: ADTCrateFishFreezer
   cost: 1000
-  category: Food
+  category: cargoproduct-category-name-food
   group: market

--- a/Resources/Prototypes/ADT/Catalog/Fills/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/ADT/Catalog/Fills/Cargo/cargo_fun.yml
@@ -5,7 +5,7 @@
     state: icon
   product: ADTCrateOktoberfestCloth
   cost: 750
-  category: Fun
+  category: cargoproduct-category-name-fun
   group: market
 
 - type: cargoProduct
@@ -15,7 +15,7 @@
     state: classicpaulaner_mug
   product: ADTCrateOktoberfestMug
   cost: 200
-  category: Fun
+  category: cargoproduct-category-name-fun
   group: market
 
 - type: cargoProduct
@@ -25,7 +25,7 @@
     state: pennywise
   product: ADTCrateHalloweenCloth
   cost: 4250
-  category: Fun
+  category: cargoproduct-category-name-fun
   group: market
 
 - type: cargoProduct
@@ -37,7 +37,7 @@
     state: christmas_tree
   product: ADTCrateChristmasTree
   cost: 250
-  category: Fun
+  category: cargoproduct-category-name-fun
   group: market
 
 - type: cargoProduct
@@ -47,7 +47,7 @@
     state: tape
   product: ADTCrateFunBoomBoxTapes1
   cost: 5000
-  category: Fun
+  category: cargoproduct-category-name-fun
   group: market
 
 - type: cargoProduct
@@ -57,7 +57,7 @@
     state: tape
   product: ADTCrateFunBoomBoxTapes2
   cost: 5000
-  category: Fun
+  category: cargoproduct-category-name-fun
   group: market
 
 - type: cargoProduct
@@ -67,5 +67,5 @@
     state: tape
   product: ADTCrateFunBoomBoxTapesHotline
   cost: 5000
-  category: Fun
+  category: cargoproduct-category-name-fun
   group: market

--- a/Resources/Prototypes/ADT/Catalog/Fills/Cargo/cargo_service.yml
+++ b/Resources/Prototypes/ADT/Catalog/Fills/Cargo/cargo_service.yml
@@ -5,5 +5,5 @@
     state: base
   product: ADTCrateVendingMachineRestockStyleoMatFilled
   cost: 4000
-  category: Service
+  category: cargoproduct-category-name-service
   group: market

--- a/Resources/Prototypes/ADT/KD/Cargo/GravityForCargo.yml
+++ b/Resources/Prototypes/ADT/KD/Cargo/GravityForCargo.yml
@@ -5,7 +5,7 @@
     state: on
   product: GravityGeneratorMini
   cost: 4000
-  category: Shuttle
+  category: cargoproduct-category-name-shuttle
   group: market
 
 - type: cargoProduct
@@ -15,5 +15,5 @@
     state: on
   product: CrateEngineeringGravityGenerator
   cost: 20000
-  category: Shuttle
+  category: cargoproduct-category-name-shuttle
   group: market

--- a/Resources/Prototypes/ADT/KD/Cargo/RingBox.yml
+++ b/Resources/Prototypes/ADT/KD/Cargo/RingBox.yml
@@ -5,5 +5,5 @@
     state: box
   product: RingBox
   cost: 8000
-  category: Fun
+  category: cargoproduct-category-name-fun
   group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_cargo.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_cargo.yml
@@ -28,5 +28,5 @@
     state: icon
   product: ADTCargoUtilisatorComplectCrate
   cost: 5000
-  category: Cargo
+  category: cargoproduct-category-name-cargo
   group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
@@ -146,7 +146,7 @@
     state: icon
   product: CrateEngineeringVoidJetpack
   cost: 8000
-  category: Engineering
+  category: cargoproduct-category-name-engineering
   group: market
 
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -25,7 +25,7 @@
     state: nutribrick
   product: CrateFoodMRE
   cost: 1800
-  category: Food
+  category: cargoproduct-category-name-food
   group: market
 
 - type: cargoProduct
@@ -35,7 +35,7 @@
     state: flour-big
   product: CrateFoodCooking
   cost: 4100
-  category: Food
+  category: cargoproduct-category-name-food
   group: market
 
 - type: cargoProduct

--- a/Resources/Prototypes/Catalog/Cargo/cargo_livestock.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_livestock.yml
@@ -145,7 +145,7 @@
     state: icon-0
   product: CrateNPCMouse
   cost: 15000
-  category: Livestock
+  category: cargoproduct-category-name-livestock
   group: market
 
 - type: cargoProduct

--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -5,7 +5,7 @@
     state: glass_3
   product: CrateMaterialGlass
   cost: 3500
-  category: Materials
+  category: cargoproduct-category-name-materials
   group: market
 
 - type: cargoProduct
@@ -15,7 +15,7 @@
     state: steel_3
   product: CrateMaterialSteel
   cost: 3500
-  category: Materials
+  category: cargoproduct-category-name-materials
   group: market
 
 - type: cargoProduct
@@ -25,7 +25,7 @@
     state: plastic_3
   product: CrateMaterialPlastic
   cost: 2500
-  category: Materials
+  category: cargoproduct-category-name-materials
   group: market
 
 - type: cargoProduct
@@ -35,7 +35,7 @@
     state: plasteel_3
   product: CrateMaterialPlasteel
   cost: 5000
-  category: Materials
+  category: cargoproduct-category-name-materials
   group: market
 
 - type: cargoProduct
@@ -55,7 +55,7 @@
     state: plasma # Corvax-Resprite
   product: CrateMaterialPlasma
   cost: 7500
-  category: Materials
+  category: cargoproduct-category-name-materials
   group: market
 
 - type: cargoProduct

--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -86,7 +86,7 @@
     state: brigmedlocked
   product: ADTCrateSecurityBrigmedic
   cost: 4000
-  category: Security
+  category: cargoproduct-category-name-security
   group: market
 
 - type: cargoProduct
@@ -96,7 +96,7 @@
     state: icon
   product: CrateSecurityHardsuit
   cost: 5000
-  category: Security
+  category: cargoproduct-category-name-security
   group: market
 
 - type: cargoProduct
@@ -106,5 +106,5 @@
     state: icon
   product: CrateSecurityUSSPjuggernaut
   cost: 12000
-  category: Security
+  category: cargoproduct-category-name-security
   group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -13,7 +13,7 @@
     state: base
   product: CrateVendingMachineRestockBoozeFilled
   cost: 3500
-  category: Service
+  category: cargoproduct-category-name-service
   group: market
 
 - type: cargoProduct
@@ -24,7 +24,7 @@
     state: base
   product: CrateVendingMachineRestockChefvendFilled
   cost: 1400
-  category: Service
+  category: cargoproduct-category-name-service
   group: market
 
 - type: cargoProduct
@@ -34,7 +34,7 @@
     state: base
   product: CrateVendingMachineRestockClothesFilled
   cost: 7000
-  category: Service
+  category: cargoproduct-category-name-service
   group: market
 
 - type: cargoProduct
@@ -44,7 +44,7 @@
     state: base
   product: CrateVendingMachineRestockDinnerwareFilled
   cost: 2000
-  category: Service
+  category: cargoproduct-category-name-service
   group: market
 
 - type: cargoProduct
@@ -55,7 +55,7 @@
     state: base
   product: CrateVendingMachineRestockCondimentStationFilled
   cost: 300
-  category: Service
+  category: cargoproduct-category-name-service
   group: market
 
 - type: cargoProduct
@@ -65,7 +65,7 @@
     state: base
   product: CrateVendingMachineRestockEngineeringFilled
   cost: 3200
-  category: Engineering
+  category: cargoproduct-category-name-engineering
   group: market
 
 - type: cargoProduct
@@ -75,7 +75,7 @@
     state: base
   product: CrateVendingMachineRestockGamesFilled
   cost: 750
-  category: Service
+  category: cargoproduct-category-name-service
   group: market
 
 - type: cargoProduct
@@ -85,7 +85,7 @@
     state: base
   product: CrateVendingMachineRestockHotDrinksFilled
   cost: 1200
-  category: Service
+  category: cargoproduct-category-name-service
   group: market
 
 - type: cargoProduct
@@ -95,7 +95,7 @@
     state: base
   product: CrateVendingMachineRestockMedicalFilled
   cost: 2700
-  category: Medical
+  category: cargoproduct-category-name-medical
   group: market
 
 - type: cargoProduct
@@ -105,7 +105,7 @@
     state: base
   product: CrateVendingMachineRestockChemVendFilled
   cost: 5090
-  category: Medical
+  category: cargoproduct-category-name-medical
   group: market
 
 - type: cargoProduct
@@ -115,7 +115,7 @@
     state: base
   product: CrateVendingMachineRestockNutriMaxFilled
   cost: 2400
-  category: Hydroponics
+  category: cargoproduct-category-name-hydroponics
   group: market
 
 - type: cargoProduct
@@ -125,7 +125,7 @@
     state: base
   product: CrateVendingMachineRestockPTechFilled
   cost: 1200
-  category: Service
+  category: cargoproduct-category-name-service
   group: market
 
 - type: cargoProduct
@@ -135,7 +135,7 @@
     state: base
   product: CrateVendingMachineRestockRobustSoftdrinksFilled
   cost: 1200
-  category: Service
+  category: cargoproduct-category-name-service
   group: market
 
 - type: cargoProduct
@@ -145,7 +145,7 @@
     state: base
   product: CrateVendingMachineRestockSalvageEquipmentFilled
   cost: 1000
-  category: Engineering
+  category: cargoproduct-category-name-engineering
   group: market
 
 - type: cargoProduct
@@ -155,7 +155,7 @@
     state: base
   product: CrateVendingMachineRestockSecTechFilled
   cost: 2200
-  category: Security
+  category: cargoproduct-category-name-security
   group: market
 
 - type: cargoProduct
@@ -165,7 +165,7 @@
     state: base
   product: CrateVendingMachineRestockSeedsFilled
   cost: 3800
-  category: Hydroponics
+  category: cargoproduct-category-name-hydroponics
   group: market
 
 - type: cargoProduct
@@ -175,7 +175,7 @@
     state: base
   product: CrateVendingMachineRestockSmokesFilled
   cost: 1200
-  category: Service
+  category: cargoproduct-category-name-service
   group: market
 
 - type: cargoProduct
@@ -185,7 +185,7 @@
     state: base
   product: CrateVendingMachineRestockVendomatFilled
   cost: 1200
-  category: Service
+  category: cargoproduct-category-name-service
   group: market
 
 - type: cargoProduct
@@ -195,7 +195,7 @@
     state: base
   product: CrateVendingMachineRestockRoboticsFilled
   cost: 1600
-  category: Science
+  category: cargoproduct-category-name-science
   group: market
 
 - type: cargoProduct
@@ -205,7 +205,7 @@
     state: base
   product: CrateVendingMachineRestockTankDispenserFilled
   cost: 1000
-  category: Atmospherics
+  category: cargoproduct-category-name-atmospherics
   group: market
 
 - type: cargoProduct
@@ -215,7 +215,7 @@
     state: base
   product: CrateVendingMachineRestockHappyHonkFilled
   cost: 2100
-  category: Service
+  category: cargoproduct-category-name-service
   group: market
 
 - type: cargoProduct
@@ -225,7 +225,7 @@
     state: base
   product: CrateVendingMachineRestockGetmoreChocolateCorpFilled
   cost: 1200
-  category: Service
+  category: cargoproduct-category-name-service
   group: market
 
 - type: cargoProduct
@@ -235,7 +235,7 @@
     state: base
   product: CrateVendingMachineRestockChangFilled
   cost: 1200
-  category: Service
+  category: cargoproduct-category-name-service
   group: market
 
 - type: cargoProduct
@@ -245,7 +245,7 @@
     state: base
   product: CrateVendingMachineRestockDiscountDansFilled
   cost: 1200
-  category: Service
+  category: cargoproduct-category-name-service
   group: market
 
 - type: cargoProduct
@@ -255,5 +255,5 @@
     state: base
   product: CrateVendingMachineRestockDonutFilled
   cost: 1200
-  category: Service
+  category: cargoproduct-category-name-service
   group: market

--- a/Resources/Prototypes/Corvax/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Corvax/Catalog/Cargo/cargo_food.yml
@@ -5,6 +5,6 @@
     state: kvass
   product: KvassTankFull
   cost: 2000
-  category: Food
+  category: cargoproduct-category-name-food
   group: market
 


### PR DESCRIPTION
Этот PR исправляет дублирование категорий в консоли заказов карго. Раньше у нас были категории типа "Шаттл и Shuttle", теперь все товары из этих категорий находятся в "Шаттл". Дополнение к 6e38b992

<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
<!-- Ниже опишите ваш Pull Request. Что он изменяет? На что еще это может повлиять? Постарайтесь описать все внесённые вами изменения! -->

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

Исправлены категории товаров в консоли заказов карго
![Снимок](https://github.com/xtray85/space_station/assets/87994977/be5bac0b-2df9-44d4-8251-fbc66024cbbd)

