### PR TITLE
Изменение лимита букв в консолях связи

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1660,7 +1660,7 @@ namespace Content.Shared.CCVar
             CVarDef.Create("chat.max_message_length", 1000, CVar.SERVER | CVar.REPLICATED);
 
         public static readonly CVarDef<int> ChatMaxAnnouncementLength =
-            CVarDef.Create("chat.max_announcement_length", 256, CVar.SERVER | CVar.REPLICATED);
+            CVarDef.Create("chat.max_announcement_length", 512, CVar.SERVER | CVar.REPLICATED);
 
         public static readonly CVarDef<bool> ChatSanitizerEnabled =
             CVarDef.Create("chat.chat_sanitizer_enabled", true, CVar.SERVERONLY);


### PR DESCRIPTION
Изменение количество лимита букв в консолях связи с 256 символов до 512
Примерно выглядит так с измененным лимитом
![изображение](https://github.com/xtray85/space_station/assets/131589665/0247c3d7-9cdc-4870-99ef-db2ce4b9b874)
