### PR TITLE
Добавление системы сразу изученных спеллов

### DIFF
--- a/Content.Server/Sirena/LearnedSpells/LearnedSpellsComponent.cs
+++ b/Content.Server/Sirena/LearnedSpells/LearnedSpellsComponent.cs
@@ -1,0 +1,31 @@
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+
+namespace Content.Server.Sirena.LearnedSpells;
+
+[RegisterComponent]
+public sealed partial class LearnedSpellsComponent : Component
+{
+    // Я и без вас знаю что это пиздец ебучий. Найдёте способ сделать динам. массивом - пинганите (by NekoDar)
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))] public string? Spell1;
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))] public string? Spell2;
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))] public string? Spell3;
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))] public string? Spell4;
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))] public string? Spell5;
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))] public string? Spell6;
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))] public string? Spell7;
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))] public string? Spell8;
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))] public string? Spell9;
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))] public string? Spell10;
+
+    [DataField] public EntityUid? SpellContainer1;
+    [DataField] public EntityUid? SpellContainer2;
+    [DataField] public EntityUid? SpellContainer3;
+    [DataField] public EntityUid? SpellContainer4;
+    [DataField] public EntityUid? SpellContainer5;
+    [DataField] public EntityUid? SpellContainer6;
+    [DataField] public EntityUid? SpellContainer7;
+    [DataField] public EntityUid? SpellContainer8;
+    [DataField] public EntityUid? SpellContainer9;
+    [DataField] public EntityUid? SpellContainer10;
+}

--- a/Content.Server/Sirena/LearnedSpells/LearnedSpellsSystem.cs
+++ b/Content.Server/Sirena/LearnedSpells/LearnedSpellsSystem.cs
@@ -1,0 +1,48 @@
+using Content.Shared.Actions;
+
+namespace Content.Server.Sirena.LearnedSpells;
+
+public sealed class LearnedSpellsSystem : EntitySystem
+{
+    [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<LearnedSpellsComponent, ComponentInit>(OnComponentInit);
+    }
+
+    private void OnComponentInit(EntityUid uid, LearnedSpellsComponent component, ComponentInit args)
+    {
+        // Я и без вас знаю что это пиздец ебучий. Найдёте способ сделать динам. массивом - пинганите (by NekoDar)
+        if (component.Spell1 != null)
+            _actionsSystem.AddAction(uid, ref component.SpellContainer1, component.Spell1);
+
+        if (component.Spell2 != null)
+            _actionsSystem.AddAction(uid, ref component.SpellContainer2, component.Spell2);
+
+        if (component.Spell3 != null)
+            _actionsSystem.AddAction(uid, ref component.SpellContainer3, component.Spell3);
+
+        if (component.Spell4 != null)
+            _actionsSystem.AddAction(uid, ref component.SpellContainer4, component.Spell4);
+
+        if (component.Spell5 != null)
+            _actionsSystem.AddAction(uid, ref component.SpellContainer5, component.Spell5);
+
+        if (component.Spell6 != null)
+            _actionsSystem.AddAction(uid, ref component.SpellContainer6, component.Spell6);
+
+        if (component.Spell7 != null)
+            _actionsSystem.AddAction(uid, ref component.SpellContainer7, component.Spell7);
+
+        if (component.Spell8 != null)
+            _actionsSystem.AddAction(uid, ref component.SpellContainer8, component.Spell8);
+
+        if (component.Spell9 != null)
+            _actionsSystem.AddAction(uid, ref component.SpellContainer9, component.Spell9);
+
+        if (component.Spell10 != null)
+            _actionsSystem.AddAction(uid, ref component.SpellContainer10, component.Spell10);
+    }
+}


### PR DESCRIPTION
# Описание PR
Данный PR добавляет систему изученных кастов. По сути оно сделано через костыли, ибо оригинальный автор (NekoDar) не знает как работать со списком при actions. 
Ограничения - 10 спеллов за раз

## Проверки
- [x] Этот запрос был полностью завершён и мне **не** нужна помощь чтобы его закончить.
- [x] Я запускал локальный сервер со своими изменениями и внимательно всё протестировал.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Медиа
![image](https://github.com/xtray85/space_station/assets/143436581/0016fc59-644d-4767-8e2e-1bb52dab1084)
![image](https://github.com/xtray85/space_station/assets/143436581/f78b1658-a549-46a3-a889-c7f10d12e1de)


## Изменения
:cl: NekoDar
- add: Компонент для сразу изученных спеллов. Пригодиться ивентерам наверное :)

Reviewed-on: https://codeberg.org/Sirena/SS14-Sirena/pulls/313

Co-committed-by: Neko_Dar <neko-d-05@mail.ru>
