### PR TITLE
Фикс красных кристаллов

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/crystal.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/crystal.yml
@@ -26,4 +26,7 @@
         - CrystalCyan
         - CrystalCyanSmall
         - CrystalCyanMedium
+        - CrystalRed
+        - CrystalRedSmall
+        - CrystalRedMedium
       chance: 0.7


### PR DESCRIPTION
## Описание PR
В предыдущем PR-е забыл прописать спавн красных кристаллов, изз-за чего их нельзя было нормально получить в IC.

**Проверки**
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl: username228
- fix: Красные кристаллы теперь могут встречаться при рандомной генерации.
