### PR TITLE
Возвращаем крафт мех фабрикатора

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -439,6 +439,7 @@
     - ProtolatheMachineCircuitboard
     - AutolatheMachineCircuitboard
     - CircuitImprinterMachineCircuitboard
+    - ExosuitFabricatorMachineCircuitboard
     - OreProcessorMachineCircuitboard
     - MaterialReclaimerMachineCircuitboard
     - ElectrolysisUnitMachineCircuitboard
@@ -520,7 +521,6 @@
       - GasRecyclerMachineCircuitboard
       - SeedExtractorMachineCircuitboard
       - AnalysisComputerCircuitboard
-      - ExosuitFabricatorMachineCircuitboard
       - AnomalyVesselCircuitboard
       - AnomalyVesselExperimentalCircuitboard
       - AnomalySynchronizerCircuitboard


### PR DESCRIPTION
## Описание PR
Починен баг, не позволяющий печатать схему фабрикатора мехов в принтерах.
![image](https://github.com/xtray85/space_station/assets/143436581/ce1778f4-a5d0-4914-9325-5140234a0bbb)

**Проверки**
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl: Username228
- fix: Плата фабрикатора мехов снова печатается.
